### PR TITLE
Handle misspecified htmlwidget dependencies

### DIFF
--- a/bin/build_rmd.R
+++ b/bin/build_rmd.R
@@ -81,8 +81,25 @@ deps <- unique(deps)
 deps <- lapply(deps, FUN = function(d) {
   # create path for htmlwidgets
   htmlwidgets <- str_extract(d$src$file, 'htmlwidgets.*')
-  htmlwidgets_dest <- file.path('docs', 'assets', dirname(htmlwidgets))
-  dir.create(htmlwidgets, showWarnings = FALSE, recursive = TRUE)
+  if (is.na(htmlwidgets)) {
+    if (d$name == 'leaflet-providers') {
+      htmlwidgets = 'htmlwidgets/lib/leaflet-providers'
+      d$src$file = file.path(system.file(package = 'leaflet.providers'), d$script)
+      htmlwidgets_dest <- file.path('docs', 'assets', htmlwidgets, '')
+    } else if (d$name == 'PopupTable') {
+      htmlwidgets = 'htmlwidgets/lib/popup'
+      d$src$file = file.path(
+        system.file(package = 'mapview'),
+        'htmlwidgets',
+        'lib',
+        'css',
+        '')
+      d$stylesheet = 'mapview-popup.css'
+      htmlwidgets_dest <- file.path('docs', 'assets', htmlwidgets)
+    }
+  } else {
+    htmlwidgets_dest <- file.path('docs', 'assets', dirname(htmlwidgets))
+  }
   system2('rsync', c('-a', '--update', d$src$file, htmlwidgets_dest))
   d$src <- htmlwidgets
   return(unclass(d))


### PR DESCRIPTION
Updates to the leaflet and mapview packages broke the previously straightforward capture of dependencies for their associated htmlwidgets. For leaflet, the data on providers was migrated to its own package, but the location of the JS files is non-standard. For mapview, the JS and CSS files for popups relocated; the new location may be standard and it may be that knitr is having trouble pulling the appropriate metadata. This PR provides a work around until those packages can be updated.

This PR also removes the buggy line that created empty folder tree, starting with htmlwidgets, in the project root on build.