### PR TITLE
fix display equations

### DIFF
--- a/docs/_views/course.md
+++ b/docs/_views/course.md
@@ -23,7 +23,7 @@ Lesson {{ site.data.lesson.lesson }} with *{{ site.data.lesson.instructor }}*
 <a name="{{ id }}"></a>
 {% assign vslides = hslide.content | split: "<p>===</p>" %}
 {% for vslide in vslides %}
-{{ vslide }}
+<section>{{ vslide }}</section>
 {% endfor %}
 [Top of Section](#{{ id }})
 {:.ToS}

--- a/docs/_views/default.md
+++ b/docs/_views/default.md
@@ -32,7 +32,7 @@ permalink: /index.html
 <a name="{{ id }}"></a>
 {% assign vslides = hslide.content | split: "<p>===</p>" %}
 {% for vslide in vslides %}
-{{ vslide }}
+<section>{{ vslide }}</section>
 {% endfor %}
 [Top of Section](#{{ id }})
 {:.ToS}


### PR DESCRIPTION
The issue identified in sesync-ci/raster-time-series-alaska-lesson#3 was not a kramdown bug, but a change in kramdown's treatment of the `$$` tag caused an otherwise harmless bug in the `_views` collection to reveal itself. The problem is that the content injected by the liquid tag `{{ vslide }}` in `_views/default.md` (for example) is *rendered*. (Surprisingly, even `{{ vslide.content }}` would still be rendered, despite Jekyll documentation ... and despite jekyll/jekyll#6209, which has been ignored). The `{{ vslide }}` is HTML with the usual `\[ .... \]` and `\( ... )\` fences for MathJax. Because the views are `.md` files however, these tags got put through kramdown a second time and this broke one of the fences (I did not investigate why). The solution is to protect the already rendered content by wrapping it all in an HTML tag, and `<section>` matches usage in the other members of `_views`.